### PR TITLE
pygame-lesson1.py: Return an exit code of 0 on an expected exit

### DIFF
--- a/PythonLessons/PyGame/pygame-lesson1.py
+++ b/PythonLessons/PyGame/pygame-lesson1.py
@@ -43,4 +43,4 @@ while True:
         # Check to see if the "Close" button has been pressed
         if event.type == pygame.QUIT:
             pygame.quit()
-            sys.exit(1)
+            sys.exit(0)


### PR DESCRIPTION
It seems more correct to return a zero exit code as if the code gets here and exits everything is fine, i.e. there is no error.